### PR TITLE
Fix Microsoft Entra ID compatibility

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Oidc/Api/AuthController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Oidc/Api/AuthController.php
@@ -144,6 +144,10 @@ class AuthController extends ApiControllerBase
             }
 
             // Create the user if allowed
+            // Fallback: use local part of email when username claim is empty
+            if (empty($lookupUsername) && !empty($lookupEmail)) {
+                $lookupUsername = strstr($lookupEmail, '@', true);
+            }
             $localUser = $this->createLocalUser($lookupUsername, $lookupEmail, $user->name ?? '',  $auth->oidcDefaultGroups);
             if ($localUser === false) {
                 $this->response->setStatusCode(500, "User creation failed");

--- a/src/opnsense/mvc/app/library/OPNsense/Oidc/OidcClient.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Oidc/OidcClient.php
@@ -78,7 +78,7 @@ class OidcClient extends OpenIDConnectClient
 
     private static function stripWellKnown($providerUrl) {
         $position = strpos($providerUrl, '.well-known/');
-        if ($position >= 0)
+        if ($position !== false)
             return substr($providerUrl, 0, $position);
         return $providerUrl;
     }


### PR DESCRIPTION
Two small fixes for Microsoft Entra ID (Azure AD) compatibility:

**1. stripWellKnown bug (OidcClient.php)**

`strpos` returns `false` when the substring is not found. The condition `$position >= 0` evaluates to `true` because `false >= 0` is true in PHP. This truncates the provider URL to an empty string, causing a curl error ("No host part in the URL").

Fix: use `$position !== false` instead.

**2. Empty username claim fallback (AuthController.php)**

Microsoft Entra ID v2.0 does not include `preferred_username` in the UserInfo endpoint response (it is only in the id_token). When the configured username claim is empty, user creation fails because the username is blank.

Fix: fall back to the local part of the email address (before the @) when the username claim is empty.

Tested with Microsoft Entra ID (tenant with Azure AD P2) on OPNsense 26.1.6.